### PR TITLE
Fix libdir for fedora/debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse3 -O2 -funroll-loops -ftree-vectorize -ffast-math")
 
+include(GNUInstallDirs)
+
 #set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 #enable_language(Fortran)
@@ -53,5 +55,5 @@ set_target_properties(cint PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 target_link_libraries(cint ${BLAS_LIBRARIES})
 
-install(TARGETS cint DESTINATION lib)
-install(FILES ${PROJECT_BINARY_DIR}/include/cint.h DESTINATION include)
+install(TARGETS cint DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
+install(FILES ${PROJECT_BINARY_DIR}/include/cint.h DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
The library directory in fedora/debian changes depending on the architecture. Eg. /usr/lib64/ for x86_64 and /usr/lib for i686. 

By using the GNUInstallDirs plugin, you're guaranteed to install the .so in the correct place every time. 
