### PR TITLE
set SIMDD with CMake configure_file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,26 @@ check_function_exists(sqrtl HAVE_SQRTL)
 #set(CMAKE_REQUIRED_LIBRARIES quadmath)
 #check_function_exists(fabsq HAVE_QUADMATH_H)
 
+include(CheckNativeVectorization)
+check_native_vectorization()
+message("sse3 works: ${SSE3_WORKS}")
+message("avx works: ${AVX_WORKS}")
+message("avx512f works: ${AVX512F_WORKS}")
+if(AVX512F_WORKS)
+  set(QCINT_VECTOR_LEVEL "avx512f")
+  set(QCINT_SIMDD 8)
+elseif(AVX_WORKS)
+  set(QCINT_VECTOR_LEVEL "avx")
+  set(QCINT_SIMDD 4)
+elseif(SSE3_WORKS)
+  set(QCINT_VECTOR_LEVEL "sse3")
+  set(QCINT_SIMDD 2)
+else()
+  message(FATAL_ERROR "SSE3 is the minimum supported instruction set")
+endif()
+
+message("Will compile with vectorization width: ${QCINT_VECTOR_LEVEL}, SIMDD=${QCINT_SIMDD}")
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/src/cint_config.h.in"
   "${PROJECT_BINARY_DIR}/src/cint_config.h")

--- a/cmake/CheckNativeVectorization.cmake
+++ b/cmake/CheckNativeVectorization.cmake
@@ -1,0 +1,104 @@
+# The C source code in this file is subject to the following license:
+# MIT License
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE
+
+macro(check_native_vectorization)
+  # Check for native vectorization
+  include(CheckCSourceRuns)
+  check_c_source_runs("
+  #include <immintrin.h>
+  int main ()
+  {
+    volatile __m128 a, b, c;
+    const float src[4] = { 1.0f, 2.0f, 3.0f, 4.0f };
+    float dst[4];
+    a = _mm_loadu_ps( src );
+    b = _mm_loadu_ps( src );
+    c = _mm_hadd_ps( a, b );
+    _mm_storeu_ps( dst, c );
+    if( dst[0] != 3.0f || dst[1] != 7.0f || dst[2] != 3.0f || dst[3] != 7.0f ){
+      return -1;
+    }
+    return 0;
+  }"
+  SSE3_WORKS)
+
+    check_c_source_runs("
+    #include <immintrin.h>
+    int main()
+    {
+        volatile __m256 a, b, c;
+        const float src[8] = { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f };
+        float dst[8];
+        a = _mm256_loadu_ps( src );
+        b = _mm256_loadu_ps( src );
+        c = _mm256_add_ps( a, b );
+        _mm256_storeu_ps( dst, c );
+        for( int i = 0; i < 8; i++ ){
+            if( ( src[i] + src[i] ) != dst[i] ){
+                return -1;
+            }
+        }
+        return 0;
+    }"
+    AVX_WORKS)
+
+    check_c_source_runs("
+    #include <immintrin.h>
+    int main()
+    {
+      volatile __m256i a, b, c;
+      const int src[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+      int dst[8];
+      a =  _mm256_loadu_si256( (__m256i*)src );
+      b =  _mm256_loadu_si256( (__m256i*)src );
+      c = _mm256_add_epi32( a, b );
+      _mm256_storeu_si256( (__m256i*)dst, c );
+      for( int i = 0; i < 8; i++ ){
+        if( ( src[i] + src[i] ) != dst[i] ){
+          return -1;
+        }
+      }
+      return 0;
+    }"
+    AVX2_WORKS)
+
+    check_c_source_runs("
+        #include <immintrin.h>
+        int main()
+        {
+            volatile __m512d a, b, c;
+            const double src[8] = { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+            double dst[8];
+            a = _mm512_loadu_pd( src );
+            b = _mm512_loadu_pd( src );
+            c = _mm512_add_pd( a, b );
+            _mm512_storeu_pd( (__m512d*) dst, c );
+            for( int i = 0; i < 8; i++ ){
+                if( ( src[i] + src[i] ) != dst[i] ){
+                    return -1;
+                }
+            }
+            return 0;
+        }"
+    AVX512F_WORKS)
+endmacro()

--- a/include/cint.h.in
+++ b/include/cint.h.in
@@ -148,13 +148,9 @@
 #include <immintrin.h>
 #include <mm_malloc.h>
 
-#ifdef __AVX512F__
-#define SIMDD   8
-#elif __AVX__
-#define SIMDD   4
-#elif __SSE3__
-#define SIMDD   2
-#endif
+#cmakedefine QCINT_SIMDD @QCINT_SIMDD@
+#define SIMDD QCINT_SIMDD
+
 
 #if defined(__GNUC__)
 #define ALIGN16 __attribute__((aligned(16)))

--- a/include/cint.h.in
+++ b/include/cint.h.in
@@ -149,8 +149,17 @@
 #include <mm_malloc.h>
 
 #cmakedefine QCINT_SIMDD @QCINT_SIMDD@
+#ifdef QCINT_SIMDD
 #define SIMDD QCINT_SIMDD
-
+#else
+#ifdef __AVX512F__
+#define SIMDD   8
+#elif __AVX__
+#define SIMDD   4
+#elif __SSE3__
+#define SIMDD   2
+#endif
+#endif
 
 #if defined(__GNUC__)
 #define ALIGN16 __attribute__((aligned(16)))


### PR DESCRIPTION
This change is intended to prevent errors such as https://github.com/pyscf/pyscf/issues/1855 from occurring.
Currently, the definition of SIMDD in `cint.h` depends on the flags passed to the compiler. If code that uses qcint is not compiled with the same flags as qcint itself, then it may assume a different value of SIMDD and access CINTEnvVars incorrectly.

I think it's a good idea for SIMDD be determined ahead of time using `check_c_source_runs` and then written to `cint.h`. 
This should ensure that downstream code gets the right value of SIMDD no matter what compile flags are used. Let me know what you think!